### PR TITLE
Replace header logo with uploaded asset

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -35,31 +35,14 @@ const Header: React.FC = () => {
         <Link
           to="/"
           onClick={closeMenu}
-          style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}
+          style={{ display: "flex", alignItems: "center" }}
+          aria-label="St. John&apos;s Auto Repair home"
         >
-          <span
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: "2.75rem",
-              height: "2.75rem",
-              borderRadius: "9999px",
-              background: "linear-gradient(135deg, var(--secondary), #1d4ed8)",
-              color: "white",
-              fontWeight: 700,
-            }}
-          >
-            SJ
-          </span>
-          <div>
-            <p style={{ fontWeight: 700, fontSize: "1.1rem", lineHeight: 1.1 }}>
-              St. John&apos;s Auto Repair
-            </p>
-            <p style={{ fontSize: "0.85rem", color: "var(--muted)" }}>
-              Trusted Mobile Mechanic in Jacksonville
-            </p>
-          </div>
+          <img
+            src="/images/saint_johns_logo_nav.png"
+            alt="St. John&apos;s Auto Repair"
+            style={{ height: "3rem", width: "auto" }}
+          />
         </Link>
 
         <nav
@@ -98,14 +81,12 @@ const Header: React.FC = () => {
           type="button"
           onClick={toggleMenu}
           aria-label="Toggle navigation menu"
+          className="header__menu-button"
           style={{
             background: "white",
             border: "1px solid rgba(148, 163, 184, 0.4)",
             borderRadius: "0.75rem",
             padding: "0.5rem 0.75rem",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "0.35rem",
           }}
         >
           <span

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -276,6 +276,12 @@ form {
   display: none;
 }
 
+.header__menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
 @media (min-width: 768px) {
   header .button.nav--desktop {
     display: inline-flex !important;
@@ -286,7 +292,7 @@ form {
     align-items: center;
   }
 
-  header button[aria-label="Toggle navigation menu"] {
+  .header__menu-button {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
- swap the header title text with the newly supplied Saint John's Auto Repair logo asset
- ensure the mobile menu button uses a CSS class so it hides on desktop layouts while keeping mobile styling intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc935d13d08328bba82bf54181b3d5