### PR TITLE
Add static export for GitHub Pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About St. John's Auto Repair</title>
+    <meta
+      name="description"
+      content="Learn about Lindon J., the ASE-certified mobile mechanic serving drivers across Jacksonville, St. Augustine, and St. Johns County."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="../public/favicon.svg" />
+    <link rel="stylesheet" href="../static/site.css" />
+    <script defer src="../static/site.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="site-header">
+        <div class="container header__inner">
+          <a class="header__brand" href="../" aria-label="St. John's Auto Repair home">
+            <img
+              src="../public/images/saint_johns_logo_nav.png"
+              alt="St. John's Auto Repair"
+            />
+          </a>
+          <nav class="nav--desktop" aria-label="Primary">
+            <a class="nav-link" href="../">Home</a>
+            <a class="nav-link nav-link--active" aria-current="page" href="./"
+              >About</a
+            >
+          </nav>
+          <a class="button nav--desktop" href="tel:+19045551234">Call for Service</a>
+          <button
+            type="button"
+            class="header__menu-button"
+            data-menu-button
+            aria-expanded="false"
+            aria-controls="mobile-navigation"
+          >
+            <span class="header__menu-icon" aria-hidden="true"></span>
+            <span>Menu</span>
+          </button>
+        </div>
+        <div
+          id="mobile-navigation"
+          class="mobile-nav"
+          data-open="false"
+          aria-hidden="true"
+        >
+          <div class="container mobile-nav__content">
+            <a class="nav-link nav-link--mobile" href="../">Home</a>
+            <a
+              class="nav-link nav-link--mobile nav-link--active"
+              aria-current="page"
+              href="./"
+              >About</a
+            >
+            <a class="button" href="tel:+19045551234">Call for Service</a>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section class="section about">
+          <div class="container about__grid">
+            <header class="stack about__intro">
+              <span class="badge">About St. John's Auto Repair</span>
+              <h1 class="section__title">
+                Local, mobile, and dedicated to keeping you rolling
+              </h1>
+              <p class="section__subtitle">
+                St. John's Auto Repair is a fully mobile shop led by ASE-certified
+                master technician Lindon J. We deliver dealership-level expertise
+                with neighborly care to drivers throughout Jacksonville and St.
+                Johns County.
+              </p>
+            </header>
+
+            <div class="grid grid--two about__content">
+              <article class="card">
+                <div class="stack">
+                  <h2>Meet Lindon</h2>
+                  <p class="helper-text about__text">
+                    Lindon started St. John's Auto Repair after more than a decade
+                    servicing domestic and import vehicles in dealership bays. He
+                    saw how often customers felt stranded by unexpected
+                    breakdowns, long waitlists, and unclear pricing. The
+                    solution: bring an expert technician and the right tools
+                    directly to you.
+                  </p>
+                </div>
+                <ul class="about__list">
+                  <li>ASE Master Certified technician</li>
+                  <li>Fully equipped mobile service van with OEM-grade diagnostics</li>
+                  <li>Transparent digital estimates before any work begins</li>
+                  <li>Respect for your driveway, schedule, and budget</li>
+                </ul>
+                <div class="about__milestones">
+                  <div class="about__milestone">
+                    <p class="about__milestone-value">12+</p>
+                    <p class="helper-text">Years of hands-on experience</p>
+                  </div>
+                  <div class="about__milestone">
+                    <p class="about__milestone-value">2,500</p>
+                    <p class="helper-text">Vehicles repaired on-site</p>
+                  </div>
+                  <div class="about__milestone">
+                    <p class="about__milestone-value">&lt; 2 hrs</p>
+                    <p class="helper-text">Average response time</p>
+                  </div>
+                </div>
+              </article>
+
+              <article class="card about__promise">
+                <h2>Our promise</h2>
+                <p>
+                  Automotive issues rarely happen on a convenient day. We bring
+                  the patience, communication, and technical skill to make
+                  stressful repairs feel manageable. From routine maintenance to
+                  urgent breakdowns, you can expect punctual arrivals, transparent
+                  quotes, and lasting repairs.
+                </p>
+                <ul>
+                  <li>Friendly updates before, during, and after every appointment</li>
+                  <li>Quality parts sourced to match or exceed OEM specifications</li>
+                  <li>Service coverage across Jacksonville, St. Augustine, and beyond</li>
+                </ul>
+                <a class="button" href="tel:+19045551234">Call to Request a Quote</a>
+              </article>
+            </div>
+
+            <section class="card about__testimonials">
+              <div class="stack">
+                <h2>What drivers are saying</h2>
+                <p class="helper-text">
+                  Word of mouth has always been our strongest referral. Here are a
+                  few notes from local customers who trust Lindon with their
+                  vehicles.
+                </p>
+              </div>
+              <div class="about__quotes">
+                <blockquote>
+                  <p>
+                    “Lindon rescued us when our SUV wouldn't start before a family
+                    trip. He arrived within the hour, diagnosed the issue
+                    immediately, and had us back on the road that afternoon.”
+                  </p>
+                  <footer class="helper-text">
+                    — Kara M., Battery &amp; alternator replacement
+                  </footer>
+                </blockquote>
+                <blockquote>
+                  <p>
+                    “I manage a small delivery fleet and rely on St. John's Auto
+                    Repair for fast, honest service. Lindon keeps every vehicle
+                    running without disrupting our schedule.”
+                  </p>
+                  <footer class="helper-text">
+                    — Devon R., Fleet maintenance client
+                  </footer>
+                </blockquote>
+                <blockquote>
+                  <p>
+                    “Fair pricing, professional communication, and the convenience
+                    of repairs in my driveway. It's the best automotive
+                    experience I've had in years.”
+                  </p>
+                  <footer class="helper-text">
+                    — Leslie T., Brake &amp; suspension service
+                  </footer>
+                </blockquote>
+              </div>
+            </section>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container footer__content">
+          <div class="footer__brand">
+            St. John's Auto Repair
+            <p class="helper-text footer__tagline">
+              Keeping Jacksonville drivers safely on the road.
+            </p>
+          </div>
+          <div class="footer__links">
+            <a class="footer__link" href="../">Home</a>
+            <a class="footer__link" href="./">About</a>
+            <a class="footer__link" href="tel:+19045551234">Call (904) 555-1234</a>
+            <a class="footer__link" href="mailto:service@stjohnsautorepair.com"
+              >service@stjohnsautorepair.com</a
+            >
+          </div>
+          <p class="footer__note">
+            &copy; <span data-current-year></span> St. John's Auto Repair. All
+            rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>St. John's Auto Repair | Mobile Mechanic in Jacksonville, FL</title>
+    <meta
+      name="description"
+      content="ASE-certified mobile mechanic providing diagnostics, repairs, and preventative maintenance across Jacksonville and St. Johns County."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="icon" type="image/svg+xml" href="public/favicon.svg" />
+    <link rel="stylesheet" href="static/site.css" />
+    <script defer src="static/site.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="site-header">
+        <div class="container header__inner">
+          <a class="header__brand" href="./" aria-label="St. John's Auto Repair home">
+            <img
+              src="public/images/saint_johns_logo_nav.png"
+              alt="St. John's Auto Repair"
+            />
+          </a>
+          <nav class="nav--desktop" aria-label="Primary">
+            <a class="nav-link nav-link--active" aria-current="page" href="./"
+              >Home</a
+            >
+            <a class="nav-link" href="about/">About</a>
+          </nav>
+          <a class="button nav--desktop" href="about/">Request a Quote</a>
+          <button
+            type="button"
+            class="header__menu-button"
+            data-menu-button
+            aria-expanded="false"
+            aria-controls="mobile-navigation"
+          >
+            <span class="header__menu-icon" aria-hidden="true"></span>
+            <span>Menu</span>
+          </button>
+        </div>
+        <div
+          id="mobile-navigation"
+          class="mobile-nav"
+          data-open="false"
+          aria-hidden="true"
+        >
+          <div class="container mobile-nav__content">
+            <a class="nav-link nav-link--mobile nav-link--active" aria-current="page" href="./"
+              >Home</a
+            >
+            <a class="nav-link nav-link--mobile" href="about/">About</a>
+            <a class="button" href="about/">Request a Quote</a>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section class="section hero">
+          <div class="container hero__grid">
+            <div class="stack">
+              <span class="badge">
+                Mobile Auto Care · Jacksonville &amp; St. Johns County
+              </span>
+              <h1 class="section__title hero__title">
+                Reliable auto repairs that come to you, wherever the road takes
+                you.
+              </h1>
+              <p class="section__subtitle hero__subtitle">
+                ASE-certified mechanic providing diagnostics, repairs, and
+                preventative maintenance at your home or workplace. Fast response
+                times, transparent pricing, and guaranteed workmanship.
+              </p>
+              <div class="hero__actions">
+                <a class="button" href="about/">Request a Quote</a>
+                <a
+                  class="button button--secondary"
+                  href="tel:+19045551234"
+                >
+                  Call (904) 555-1234
+                </a>
+              </div>
+              <div class="hero__highlights">
+                <div class="hero__highlight">
+                  <span class="hero__dot hero__dot--accent"></span>
+                  <p class="helper-text">Same-day appointments often available</p>
+                </div>
+                <div class="hero__highlight">
+                  <span class="hero__dot hero__dot--secondary"></span>
+                  <p class="helper-text">
+                    Serving Jacksonville, St. Augustine, Ponte Vedra, and
+                    surrounding areas
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div class="card hero__card">
+              <div>
+                <h2>Roadside-ready service</h2>
+                <p>
+                  Whether you're at home, at work, or stranded in a parking lot,
+                  St. John's Auto Repair brings the shop to you with fully
+                  equipped mobile diagnostics and repair tools.
+                </p>
+              </div>
+              <div class="hero__services">
+                <div class="hero__service">
+                  <span class="hero__service-dot" aria-hidden="true"></span>
+                  <p>Advanced diagnostics</p>
+                </div>
+                <div class="hero__service">
+                  <span class="hero__service-dot" aria-hidden="true"></span>
+                  <p>Preventative maintenance</p>
+                </div>
+                <div class="hero__service">
+                  <span class="hero__service-dot" aria-hidden="true"></span>
+                  <p>Electrical &amp; mechanical repairs</p>
+                </div>
+                <div class="hero__service">
+                  <span class="hero__service-dot" aria-hidden="true"></span>
+                  <p>Fleet service partnerships</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="section section--dark">
+          <div class="container">
+            <div class="stack section__intro">
+              <span class="badge badge--inverse">What we do</span>
+              <h2 class="section__title">Full-service mobile mechanic</h2>
+              <p class="section__subtitle">
+                From diagnostics to complex repairs, we deliver dealership-level
+                expertise with the personal touch of a local mechanic.
+              </p>
+            </div>
+
+            <div class="grid grid--two">
+              <article class="card card--overlay">
+                <div class="card__header">
+                  <span class="card__icon">01</span>
+                  <div>
+                    <h3>Diagnostics &amp; Electrical</h3>
+                    <p>Pinpoint issues quickly with advanced scan tools</p>
+                  </div>
+                </div>
+                <ul>
+                  <li>On-site computer diagnostics</li>
+                  <li>Battery, starter, and alternator repairs</li>
+                  <li>Electrical troubleshooting &amp; wiring repairs</li>
+                </ul>
+              </article>
+
+              <article class="card card--overlay">
+                <div class="card__header">
+                  <span class="card__icon">02</span>
+                  <div>
+                    <h3>Engine &amp; Drivetrain</h3>
+                    <p>Complete engine services without the shop wait times</p>
+                  </div>
+                </div>
+                <ul>
+                  <li>Timing belts and water pumps</li>
+                  <li>Fuel system service &amp; tune-ups</li>
+                  <li>Transmission maintenance &amp; fluid service</li>
+                </ul>
+              </article>
+
+              <article class="card card--overlay">
+                <div class="card__header">
+                  <span class="card__icon">03</span>
+                  <div>
+                    <h3>Brakes &amp; Suspension</h3>
+                    <p>Stop safely with premium components and expert installation</p>
+                  </div>
+                </div>
+                <ul>
+                  <li>Brake pad &amp; rotor replacement</li>
+                  <li>ABS system diagnostics</li>
+                  <li>Shocks, struts, and suspension components</li>
+                </ul>
+              </article>
+
+              <article class="card card--overlay">
+                <div class="card__header">
+                  <span class="card__icon">04</span>
+                  <div>
+                    <h3>Fleet &amp; Commercial</h3>
+                    <p>
+                      Keep your business vehicles on the road with flexible
+                      scheduling
+                    </p>
+                  </div>
+                </div>
+                <ul>
+                  <li>Fleet maintenance programs</li>
+                  <li>DOT inspections &amp; documentation</li>
+                  <li>After-hours and weekend availability</li>
+                </ul>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section class="section">
+          <div class="container grid grid--two why-us">
+            <div class="card why-us__details">
+              <h2 class="section__title">Why drivers choose St. John's Auto Repair</h2>
+              <div class="stack">
+                <div class="why-us__item">
+                  <span class="why-us__icon">✓</span>
+                  <div class="stack">
+                    <h3>Certified expertise at your driveway</h3>
+                    <p class="helper-text">
+                      Over 12 years of experience with domestic and import
+                      vehicles, backed by ASE Master certification.
+                    </p>
+                  </div>
+                </div>
+                <div class="why-us__item">
+                  <span class="why-us__icon">$</span>
+                  <div class="stack">
+                    <h3>Transparent, upfront pricing</h3>
+                    <p class="helper-text">
+                      Digital estimates with labor and part breakdowns. Approve
+                      work from your phone before we turn a wrench.
+                    </p>
+                  </div>
+                </div>
+                <div class="why-us__item">
+                  <span class="why-us__icon">📱</span>
+                  <div class="stack">
+                    <h3>Mobile-first experience</h3>
+                    <p class="helper-text">
+                      SMS updates, photo reports, and secure online payments keep
+                      you in control even while you're on the go.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="card why-us__cta">
+              <div class="stack">
+                <h3>Emergency help, maintenance, and everything in between.</h3>
+                <p class="helper-text">
+                  Text us photos or videos of your issue and get a repair plan
+                  within hours. We bring factory-grade tools and OEM-quality
+                  parts directly to you, eliminating the need for a tow.
+                </p>
+                <a class="button" href="about/">Get a personalized repair plan</a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer class="footer">
+        <div class="container footer__content">
+          <div class="footer__brand">
+            St. John's Auto Repair
+            <p class="helper-text footer__tagline">
+              Keeping Jacksonville drivers safely on the road.
+            </p>
+          </div>
+          <div class="footer__links">
+            <a class="footer__link" href="./">Home</a>
+            <a class="footer__link" href="about/">About</a>
+            <a class="footer__link" href="tel:+19045551234">Call (904) 555-1234</a>
+            <a class="footer__link" href="mailto:service@stjohnsautorepair.com"
+              >service@stjohnsautorepair.com</a
+            >
+          </div>
+          <p class="footer__note">
+            &copy; <span data-current-year></span> St. John's Auto Repair. All
+            rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/static/site.css
+++ b/static/site.css
@@ -1,0 +1,635 @@
+:root {
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: var(--text);
+  background-color: var(--light);
+  --primary: #1d4ed8;
+  --secondary: #1e293b;
+  --accent: #2563eb;
+  --text: #0f172a;
+  --muted: #475569;
+  --light: #f8fafc;
+  --surface: #ffffff;
+  --max-width: 1200px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  color: var(--text);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+main {
+  flex: 1;
+}
+
+.container {
+  width: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, var(--accent), #1e40af);
+  color: #f8fafc;
+  font-weight: 600;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.25);
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 32px rgba(37, 99, 235, 0.35);
+}
+
+.button--secondary {
+  background: #ffffff;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.section {
+  padding: 4rem 0;
+}
+
+.section--dark {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.95), rgba(15, 23, 42, 0.95));
+  color: #e2e8f0;
+}
+
+.section__title {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+  margin-bottom: 1rem;
+  font-weight: 700;
+}
+
+.section__subtitle {
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.section--dark .section__subtitle {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid--two {
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .grid--two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  color: var(--text);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: 9999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+}
+
+.badge--inverse {
+  background: rgba(148, 197, 255, 0.25);
+  color: #e0f2fe;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.helper-text {
+  font-size: 0.95rem;
+  color: rgba(71, 85, 105, 0.75);
+}
+
+.footer {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #e2e8f0;
+  padding: 2.5rem 0;
+}
+
+.footer__content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.footer__brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.footer__tagline {
+  color: #cbd5f5;
+  margin-top: 0.5rem;
+}
+
+.footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  color: rgba(226, 232, 240, 0.75);
+  font-size: 0.95rem;
+}
+
+.footer__note {
+  font-size: 0.85rem;
+  color: rgba(203, 213, 225, 0.65);
+}
+
+@media (min-width: 768px) {
+  .footer__content {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: center;
+  }
+}
+
+.nav-link {
+  position: relative;
+  padding-bottom: 0.25rem;
+  transition: color 0.2s ease;
+  color: rgba(15, 23, 42, 0.65);
+  font-weight: 600;
+}
+
+.nav-link:hover {
+  color: var(--accent);
+}
+
+.nav-link--active::after,
+.nav-link:hover::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.35rem;
+  width: 100%;
+  height: 0.2rem;
+  border-radius: 9999px;
+  background: var(--accent);
+}
+
+.nav-link--active {
+  color: var(--accent) !important;
+}
+
+.nav-link--mobile {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 0;
+}
+
+.nav-link--mobile:last-of-type {
+  border-bottom: none;
+}
+
+.nav--desktop {
+  display: none;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  gap: 1rem;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(248, 250, 252, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.header__brand img {
+  height: 4.5rem;
+  width: auto;
+}
+
+.header__menu-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+}
+
+.header__menu-icon {
+  width: 1.25rem;
+  height: 0.15rem;
+  background: var(--primary);
+  position: relative;
+  display: inline-block;
+  border-radius: 9999px;
+}
+
+.header__menu-icon::before,
+.header__menu-icon::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--primary);
+  border-radius: 9999px;
+}
+
+.header__menu-icon::before {
+  top: -0.4rem;
+}
+
+.header__menu-icon::after {
+  bottom: -0.4rem;
+}
+
+.mobile-nav {
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+  background: rgba(248, 250, 252, 0.98);
+  display: none;
+}
+
+.mobile-nav[data-open="true"] {
+  display: block;
+}
+
+.mobile-nav__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 1.5rem;
+}
+
+.hero {
+  padding-top: 5rem;
+}
+
+.hero__grid {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.hero__title {
+  font-size: clamp(2rem, 5vw, 3.25rem);
+}
+
+.hero__subtitle {
+  font-size: 1.1rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero__highlights {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.hero__highlight {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hero__dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 9999px;
+}
+
+.hero__dot--accent {
+  background: var(--accent);
+}
+
+.hero__dot--secondary {
+  background: var(--secondary);
+}
+
+.hero__card {
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.2), rgba(30, 64, 175, 0.7));
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero__card h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero__card p {
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.hero__services {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero__service {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.hero__service-dot {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hero__service-dot::after {
+  content: "";
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--accent);
+}
+
+.section__intro {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.card--overlay {
+  background: linear-gradient(155deg, rgba(15, 23, 42, 0.92), rgba(37, 99, 235, 0.35));
+  color: #f8fafc;
+}
+
+.card--overlay ul {
+  display: grid;
+  gap: 0.65rem;
+  color: rgba(226, 232, 240, 0.9);
+  padding-left: 1rem;
+  list-style: disc;
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.card__icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 1rem;
+  background: rgba(37, 99, 235, 0.25);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1.25rem;
+}
+
+.card__header h3 {
+  font-size: 1.3rem;
+  margin-bottom: 0.35rem;
+}
+
+.card__header p {
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+}
+
+.why-us {
+  align-items: center;
+}
+
+.why-us__details {
+  order: 2;
+}
+
+.why-us__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.why-us__icon {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 0.75rem;
+  background: rgba(37, 99, 235, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--secondary);
+}
+
+.why-us__cta {
+  order: 1;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.15), rgba(37, 99, 235, 0.35));
+}
+
+@media (min-width: 992px) {
+  .why-us__details {
+    order: 1;
+  }
+
+  .why-us__cta {
+    order: 2;
+  }
+}
+
+.about__grid {
+  display: grid;
+  gap: 3rem;
+}
+
+.about__intro {
+  gap: 1rem;
+  text-align: center;
+}
+
+.about__intro .section__subtitle {
+  margin: 0 auto;
+  max-width: 50rem;
+}
+
+.about__content {
+  align-items: stretch;
+}
+
+.about__text {
+  font-size: 1rem;
+}
+
+.about__list {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.about__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  color: var(--text);
+  font-weight: 600;
+}
+
+.about__list li::before {
+  content: "";
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: var(--accent);
+  margin-top: 0.35rem;
+}
+
+.about__milestones {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  margin-top: 1.5rem;
+}
+
+.about__milestone {
+  padding: 1rem;
+  border-radius: 0.85rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(30, 64, 175, 0.12));
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  text-align: center;
+}
+
+.about__milestone-value {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.about__promise {
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.95), rgba(30, 64, 175, 0.9));
+  color: #f8fafc;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.about__promise p {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.about__promise ul {
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.about__testimonials {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.about__quotes {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.about__quotes blockquote {
+  background: rgba(37, 99, 235, 0.08);
+  border-left: 4px solid var(--accent);
+  border-radius: 0.85rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.about__quotes p {
+  font-size: 1.05rem;
+  color: var(--text);
+  line-height: 1.6;
+}
+
+@media (min-width: 768px) {
+  .nav--desktop {
+    display: inline-flex;
+  }
+
+  .header__menu-button {
+    display: none;
+  }
+
+  .mobile-nav {
+    display: none !important;
+  }
+}

--- a/static/site.js
+++ b/static/site.js
@@ -1,0 +1,29 @@
+(function () {
+  const menuButton = document.querySelector('[data-menu-button]');
+  const mobileNav = document.getElementById('mobile-navigation');
+
+  if (menuButton && mobileNav) {
+    const toggleMenu = () => {
+      const isOpen = mobileNav.getAttribute('data-open') === 'true';
+      const nextState = !isOpen;
+      mobileNav.setAttribute('data-open', String(nextState));
+      mobileNav.setAttribute('aria-hidden', String(!nextState));
+      menuButton.setAttribute('aria-expanded', String(nextState));
+    };
+
+    menuButton.addEventListener('click', toggleMenu);
+
+    mobileNav.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (mobileNav.getAttribute('data-open') === 'true') {
+          menuButton.click();
+        }
+      });
+    });
+  }
+
+  const year = new Date().getFullYear();
+  document.querySelectorAll('[data-current-year]').forEach((node) => {
+    node.textContent = String(year);
+  });
+})();


### PR DESCRIPTION
## Summary
- add handcrafted static `index.html` and `about/index.html` mirroring the Next.js pages for direct GitHub Pages hosting
- include shared stylesheet and lightweight script to reproduce the layout, design system, and mobile navigation behavior
- keep relative links and dynamic copyright year so the export works from a project subpath without extra tooling

## Testing
- not run (static files only)


------
https://chatgpt.com/codex/tasks/task_e_68ccca89a2cc832895833ea22d6524a7