### PR TITLE
Reduce hero section top padding

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ const valueProps = [
 export default function HomePage() {
   return (
     <div>
-      <section className="section" style={{ paddingTop: "5rem" }}>
+      <section className="section" style={{ paddingTop: "2rem" }}>
         <div className="container" style={{ display: "grid", gap: "2.5rem" }}>
           <div className="stack">
             <span className="badge">


### PR DESCRIPTION
## Summary
- decrease the hero section's top padding so the header sits closer to the first content block

## Testing
- `npm run lint` *(fails: local Next.js binary not available because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cce157f13c8328b95d9b74fbd10ddb