### PR TITLE
Adjust mobile header padding

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -55,7 +55,7 @@ export default function Header() {
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          padding: "1rem 0",
+          padding: "1rem 1.25rem",
         }}
       >
         <Link


### PR DESCRIPTION
## Summary
- restore horizontal padding on the header container so the mobile menu button has breathing room from the screen edge

## Testing
- npm run lint *(fails: existing react/no-unescaped-entities errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7af051a083289eb17e2ff55af357