### PR TITLE
Adjust mobile nav padding

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -338,7 +338,7 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-bottom: 1.5rem;
+  padding: 0 1.75rem 1.5rem 1.25rem;
 }
 
 .hero {


### PR DESCRIPTION
## Summary
- add additional right-side spacing to the mobile navigation container so the menu isn't flush with the viewport edge

## Testing
- npm run lint *(fails: existing `react/no-unescaped-entities` errors in src/app and components files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7e445c348328a142cc8543225cbf