### PR TITLE
Implement quote request email backend and update contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ The pages site will be seen here [https://loganm3120.github.io/stjohnsautorepair
 - Run `npm run build && npm run export` to produce a static site in the `out/` directory that is ready to upload to GitHub Pages.
 - Update the `next.config.mjs` file if you need to set a `basePath` or `assetPrefix` for a project site hosted on a subpath.
 
+## Quote Request Email Setup
+
+The request-a-quote modal on the static pages now posts to the `/api/request-quote` endpoint. Configure SMTP credentials in a `.env` file at the project root before running the site so submissions can be delivered to `saintjohnsautorepair@gmail.com`.
+
+```env
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_USER=your_smtp_username
+SMTP_PASS=your_smtp_password_or_app_password
+SMTP_SECURE=true
+QUOTE_REQUEST_RECIPIENT=saintjohnsautorepair@gmail.com
+# Optional override for the "from" address shown in delivered emails
+# QUOTE_REQUEST_FROM="St. John's Auto Repair" <no-reply@yourdomain.com>
+```
+
+Restart the development server after editing environment variables. When a visitor opts to receive a copy of their submission, their address is included on the email as a CC recipient.
+
 ## Future Enhancements
 
 - Integrate the quote call-to-action with a backend service or CRM.

--- a/about/index.html
+++ b/about/index.html
@@ -198,8 +198,8 @@
             <a class="footer__link" href="../">Home</a>
             <a class="footer__link" href="./">About</a>
             <a class="footer__link" href="tel:+19048273869">Call +1 (904) 827-3869</a>
-            <a class="footer__link" href="mailto:service@stjohnsautorepair.com"
-              >service@stjohnsautorepair.com</a
+            <a class="footer__link" href="mailto:saintjohnsautorepair@gmail.com"
+              >saintjohnsautorepair@gmail.com</a
             >
           </div>
           <p class="footer__note">
@@ -353,6 +353,12 @@
             <div class="quote-form__actions">
               <button type="submit" class="button">Submit Request</button>
             </div>
+            <div
+              class="quote-form__status"
+              data-quote-status
+              role="status"
+              aria-live="polite"
+            ></div>
           </form>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -287,8 +287,8 @@
             <a class="footer__link" href="./">Home</a>
             <a class="footer__link" href="about/">About</a>
             <a class="footer__link" href="tel:+19048273869">Call +1 (904) 827-3869</a>
-            <a class="footer__link" href="mailto:service@stjohnsautorepair.com"
-              >service@stjohnsautorepair.com</a
+            <a class="footer__link" href="mailto:saintjohnsautorepair@gmail.com"
+              >saintjohnsautorepair@gmail.com</a
             >
           </div>
           <p class="footer__note">
@@ -442,6 +442,12 @@
             <div class="quote-form__actions">
               <button type="submit" class="button">Submit Request</button>
             </div>
+            <div
+              class="quote-form__status"
+              data-quote-status
+              role="status"
+              aria-live="polite"
+            ></div>
           </form>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "next": "^14.2.32",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "nodemailer": "^6.9.15"
   },
   "devDependencies": {
     "@types/node": "^20.16.10",
@@ -22,6 +23,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.15",
     "prettier": "^3.6.2",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "@types/nodemailer": "^6.4.15"
   }
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -3,19 +3,19 @@ import type { Metadata } from "next";
 const testimonials = [
   {
     quote:
-      "Lindon rescued us when our SUV wouldn't start before a family trip. He arrived within the hour, diagnosed the issue immediately, and had us back on the road that afternoon.",
+      "Lindon rescued us when our SUV wouldn’t start before a family trip. He arrived within the hour, diagnosed the issue immediately, and had us back on the road that afternoon.",
     name: "Kara M.",
     detail: "Battery & alternator replacement",
   },
   {
     quote:
-      "I manage a small delivery fleet and rely on St. John's Auto Repair for fast, honest service. Lindon keeps every vehicle running without disrupting our schedule.",
+      "I manage a small delivery fleet and rely on St. John’s Auto Repair for fast, honest service. Lindon keeps every vehicle running without disrupting our schedule.",
     name: "Devon R.",
     detail: "Fleet maintenance client",
   },
   {
     quote:
-      "Fair pricing, professional communication, and the convenience of repairs in my driveway. It's the best automotive experience I've had in years.",
+      "Fair pricing, professional communication, and the convenience of repairs in my driveway. It’s the best automotive experience I’ve had in years.",
     name: "Leslie T.",
     detail: "Brake & suspension service",
   },
@@ -37,7 +37,7 @@ const milestones = [
 ] as const;
 
 export const metadata: Metadata = {
-  title: "About St. John's Auto Repair",
+  title: "About St. John’s Auto Repair",
   description:
     "Learn about Lindon J., the ASE-certified mobile mechanic serving drivers across Jacksonville, St. Augustine, and St. Johns County.",
 };
@@ -47,12 +47,12 @@ export default function AboutPage() {
     <section className="section" style={{ paddingTop: "6rem" }}>
       <div className="container" style={{ display: "grid", gap: "3rem" }}>
         <header className="stack" style={{ gap: "1rem", textAlign: "center" }}>
-          <span className="badge">About St. John's Auto Repair</span>
+          <span className="badge">About St. John’s Auto Repair</span>
           <h1 className="section__title" style={{ fontSize: "clamp(2rem, 5vw, 3rem)" }}>
             Local, mobile, and dedicated to keeping you rolling
           </h1>
           <p className="section__subtitle" style={{ margin: "0 auto", maxWidth: "50rem" }}>
-            St. John's Auto Repair is a fully mobile shop led by ASE-certified master technician Lindon J. We deliver dealership-level expertise with neighborly care to drivers throughout Jacksonville and St. Johns County.
+            St. John’s Auto Repair is a fully mobile shop led by ASE-certified master technician Lindon J. We deliver dealership-level expertise with neighborly care to drivers throughout Jacksonville and St. Johns County.
           </p>
         </header>
 
@@ -61,7 +61,7 @@ export default function AboutPage() {
             <div className="stack" style={{ gap: "0.75rem" }}>
               <h2 style={{ fontSize: "1.8rem" }}>Meet Lindon</h2>
               <p className="helper-text" style={{ fontSize: "1rem" }}>
-                Lindon started St. John's Auto Repair after more than a decade servicing domestic and import vehicles in dealership bays. He saw how often customers felt stranded by unexpected breakdowns, long waitlists, and unclear pricing. The solution: bring an expert technician and the right tools directly to you.
+                Lindon started St. John’s Auto Repair after more than a decade servicing domestic and import vehicles in dealership bays. He saw how often customers felt stranded by unexpected breakdowns, long waitlists, and unclear pricing. The solution: bring an expert technician and the right tools directly to you.
               </p>
             </div>
             <ul

--- a/src/app/api/request-quote/route.ts
+++ b/src/app/api/request-quote/route.ts
@@ -1,0 +1,232 @@
+import { NextResponse } from "next/server";
+import nodemailer from "nodemailer";
+
+export const runtime = "nodejs";
+
+const FALLBACK_RECIPIENT = "saintjohnsautorepair@gmail.com";
+
+type QuoteRequestPayload = {
+  full_name?: unknown;
+  email?: unknown;
+  phone?: unknown;
+  vin?: unknown;
+  concern?: unknown;
+  preferred_contact?: unknown;
+  preferred_contact_other?: unknown;
+  send_copy?: unknown;
+};
+
+const sanitize = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : "";
+
+const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return char;
+    }
+  });
+
+const formatMultilineHtml = (value: string): string =>
+  escapeHtml(value).replace(/\r?\n/g, "<br />");
+
+const normalizePreferredContact = (
+  value: string,
+  otherValue: string,
+): { label: string; extra?: string } => {
+  const base = value ? value.toLowerCase() : "";
+
+  if (base === "other") {
+    return {
+      label: otherValue ? "Other" : "Other (unspecified)",
+      extra: otherValue,
+    };
+  }
+
+  if (!base) {
+    return { label: "Not specified" };
+  }
+
+  return { label: base.charAt(0).toUpperCase() + base.slice(1) };
+};
+
+const parseBoolean = (value: string): boolean => {
+  const normalized = value.toLowerCase();
+  return ["yes", "true", "on", "1"].includes(normalized);
+};
+
+export async function POST(request: Request) {
+  let payload: QuoteRequestPayload;
+
+  try {
+    payload = (await request.json()) as QuoteRequestPayload;
+  } catch (error) {
+    return NextResponse.json(
+      { message: "We couldn't read your request. Please try again." },
+      { status: 400 },
+    );
+  }
+
+  const fullName = sanitize(payload.full_name);
+  const email = sanitize(payload.email);
+  const phone = sanitize(payload.phone);
+  const vin = sanitize(payload.vin);
+  const concern = sanitize(payload.concern);
+  const preferredContactRaw = sanitize(payload.preferred_contact);
+  const preferredContactOther = sanitize(payload.preferred_contact_other);
+  const sendCopyRaw = sanitize(payload.send_copy);
+  const sendCopy = sendCopyRaw ? parseBoolean(sendCopyRaw) : false;
+
+  if (!fullName || !email || !phone || !concern) {
+    return NextResponse.json(
+      {
+        message:
+          "Please complete your name, email, phone number, and vehicle concern before submitting.",
+      },
+      { status: 400 },
+    );
+  }
+
+  const preferredContact = normalizePreferredContact(
+    preferredContactRaw,
+    preferredContactOther,
+  );
+  const submittedAt = new Date();
+  const submittedAtIso = submittedAt.toISOString();
+  const submittedAtLocal = submittedAt.toLocaleString("en-US", {
+    hour12: true,
+  });
+
+  const textSummary = [
+    `Full Name: ${fullName}`,
+    `Email: ${email}`,
+    `Phone: ${phone}`,
+    vin ? `VIN: ${vin}` : null,
+    `Preferred Contact: ${preferredContact.label}`,
+    preferredContact.extra
+      ? `Preferred Contact Details: ${preferredContact.extra}`
+      : null,
+    `Send Copy: ${sendCopy ? "Yes" : "No"}`,
+    `Submitted: ${submittedAtIso}`,
+    "",
+    "Vehicle Concern:",
+    concern,
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+
+  const htmlSummary = `
+    <h2>New quote request received</h2>
+    <p><strong>Submitted:</strong> ${escapeHtml(
+      submittedAtLocal,
+    )} (${escapeHtml(submittedAtIso)})</p>
+    <ul>
+      <li><strong>Full Name:</strong> ${escapeHtml(fullName)}</li>
+      <li><strong>Email:</strong> ${escapeHtml(email)}</li>
+      <li><strong>Phone:</strong> ${escapeHtml(phone)}</li>
+      ${vin ? `<li><strong>VIN:</strong> ${escapeHtml(vin)}</li>` : ""}
+      <li><strong>Preferred Contact:</strong> ${escapeHtml(
+        preferredContact.label,
+      )}</li>
+      ${preferredContact.extra
+        ? `<li><strong>Preferred Contact Details:</strong> ${escapeHtml(preferredContact.extra)}</li>`
+        : ""}
+      <li><strong>Send Copy:</strong> ${sendCopy ? "Yes" : "No"}</li>
+    </ul>
+    <p><strong>Vehicle Concern</strong></p>
+    <p>${formatMultilineHtml(concern)}</p>
+  `;
+
+  const smtpHost = process.env.SMTP_HOST;
+  const smtpPortRaw = process.env.SMTP_PORT;
+  const smtpUser = process.env.SMTP_USER;
+  const smtpPass = process.env.SMTP_PASS;
+  const smtpSecureRaw = process.env.SMTP_SECURE;
+  const fromAddress =
+    process.env.QUOTE_REQUEST_FROM ?? smtpUser ?? FALLBACK_RECIPIENT;
+  const recipient =
+    process.env.QUOTE_REQUEST_RECIPIENT ?? FALLBACK_RECIPIENT;
+
+  if (!smtpHost || !smtpPortRaw) {
+    return NextResponse.json(
+      {
+        message:
+          "We couldn't send your request at this time. Please call +1 (904) 827-3869 for immediate assistance.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const port = Number.parseInt(smtpPortRaw, 10);
+  if (Number.isNaN(port)) {
+    return NextResponse.json(
+      {
+        message:
+          "We couldn't send your request at this time. Please call +1 (904) 827-3869 for immediate assistance.",
+      },
+      { status: 500 },
+    );
+  }
+
+  if ((smtpUser && !smtpPass) || (!smtpUser && smtpPass)) {
+    return NextResponse.json(
+      {
+        message:
+          "We couldn't send your request at this time. Please call +1 (904) 827-3869 for immediate assistance.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const secure = smtpSecureRaw
+    ? smtpSecureRaw.toLowerCase() === "true"
+    : port === 465;
+
+  const transporter = nodemailer.createTransport({
+    host: smtpHost,
+    port,
+    secure,
+    auth:
+      smtpUser && smtpPass
+        ? {
+            user: smtpUser,
+            pass: smtpPass,
+          }
+        : undefined,
+  });
+
+  try {
+    await transporter.sendMail({
+      from: fromAddress,
+      to: recipient,
+      cc: sendCopy ? email : undefined,
+      replyTo: email,
+      subject: `New quote request from ${fullName}`,
+      text: textSummary,
+      html: htmlSummary,
+    });
+  } catch (error) {
+    console.error("Failed to send quote request email", error);
+    return NextResponse.json(
+      {
+        message:
+          "We couldn't send your request at this time. Please call +1 (904) 827-3869 for immediate assistance.",
+      },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({
+    message: "Quote request sent successfully.",
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import "./globals.css";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "St. John's Auto Repair | Mobile Mechanic in Jacksonville, FL",
+  title: "St. John’s Auto Repair | Mobile Mechanic in Jacksonville, FL",
   description:
     "ASE-certified mobile mechanic providing diagnostics, repairs, and preventative maintenance across Jacksonville and St. Johns County.",
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ const valueProps = [
   {
     title: "Mobile-first experience",
     description:
-      "SMS updates, photo reports, and secure online payments keep you in control even while you're on the go.",
+      "SMS updates, photo reports, and secure online payments keep you in control even while you’re on the go.",
     icon: "📱",
   },
 ] as const;
@@ -160,8 +160,8 @@ export default function HomePage() {
                 Roadside-ready service
               </h2>
               <p style={{ color: "rgba(226, 232, 240, 0.9)" }}>
-                Whether you're at home, at work, or stranded in a parking lot,
-                St. John's Auto Repair brings the shop to you with fully
+                Whether you’re at home, at work, or stranded in a parking lot,
+                St. John’s Auto Repair brings the shop to you with fully
                 equipped mobile diagnostics and repair tools.
               </p>
             </div>
@@ -300,7 +300,7 @@ export default function HomePage() {
         >
           <div className="card" style={{ order: 2 }}>
             <h2 className="section__title" style={{ fontSize: "2rem" }}>
-              Why drivers choose St. John's Auto Repair
+              Why drivers choose St. John’s Auto Repair
             </h2>
             <div className="stack">
               {valueProps.map((value) => (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ export default function Footer() {
     <footer className="footer">
       <div className="container footer__content">
         <div className="footer__brand">
-          St. John's Auto Repair
+          St. John’s Auto Repair
           <p className="helper-text" style={{ color: "#cbd5f5", marginTop: "0.5rem" }}>
             Keeping Jacksonville drivers safely on the road.
           </p>
@@ -14,12 +14,12 @@ export default function Footer() {
           <Link href="/">Home</Link>
           <Link href="/about">About</Link>
           <a href="tel:+19048273869">Call +1 (904) 827-3869</a>
-          <a href="mailto:service@stjohnsautorepair.com">
-            service@stjohnsautorepair.com
+          <a href="mailto:saintjohnsautorepair@gmail.com">
+            saintjohnsautorepair@gmail.com
           </a>
         </div>
         <p className="footer__note">
-          &copy; {new Date().getFullYear()} St. John's Auto Repair. All rights
+          &copy; {new Date().getFullYear()} St. John’s Auto Repair. All rights
           reserved.
         </p>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 'use client';
+/* eslint-disable @next/next/no-img-element */
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -62,11 +63,11 @@ export default function Header() {
           href="/"
           onClick={closeMenu}
           style={{ display: "flex", alignItems: "center" }}
-          aria-label="St. John's Auto Repair home"
+          aria-label="St. John’s Auto Repair home"
         >
           <img
             src="/images/saint_johns_logo_nav.png"
-            alt="St. John's Auto Repair"
+            alt="St. John’s Auto Repair"
             style={{ height: "4.5rem", width: "auto" }}
           />
         </Link>

--- a/static/site.css
+++ b/static/site.css
@@ -861,6 +861,31 @@ fieldset.quote-form__field {
   width: 100%;
 }
 
+.quote-form__actions .button[disabled] {
+  opacity: 0.65;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.quote-form__status {
+  min-height: 1.5rem;
+  margin-top: -0.25rem;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.quote-form__status[data-status="pending"] {
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.quote-form__status[data-status="success"] {
+  color: #15803d;
+}
+
+.quote-form__status[data-status="error"] {
+  color: #dc2626;
+}
+
 @media (min-width: 640px) {
   .quote-modal__dialog {
     padding: 3rem 2.5rem 2.5rem;


### PR DESCRIPTION
## Summary
- add a Next.js API route that delivers quote requests via SMTP and document the required environment variables
- enhance the static quote modal to post to the new endpoint, show submission status, and reset form state after sending
- replace site contact emails with saintjohnsautorepair@gmail.com and update dependencies and copy to satisfy linting

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdb201f2b88328b469336ab40faaea