### PR TITLE
Adjust header padding for mobile menu spacing

### DIFF
--- a/static/site.css
+++ b/static/site.css
@@ -271,7 +271,7 @@ main {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 0;
+  padding: 1rem clamp(1.25rem, 4vw, 2.5rem);
   gap: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- increase the header container's horizontal padding so the brand logo and menu button no longer touch the screen edge on small devices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdc198678c83288d0b120fcc8e7bb2